### PR TITLE
Handle expired delivery slots.

### DIFF
--- a/src/main/java/com/google/sps/data/DeliverySlot.java
+++ b/src/main/java/com/google/sps/data/DeliverySlot.java
@@ -61,7 +61,7 @@ public class DeliverySlot {
       throw new BadRequestException("Please enter a valid time!");
     }
     if (startTimeInMiliseconds < System.currentTimeMillis() - deliveryDay.getTime()) {
-      throw new BadRequestException("Please enter a valid date!");
+      throw new ExpiredRequestException("Please enter a valid date!");
     }
     this.startTime = new Date(deliveryDay.getTime() + startTimeInMiliseconds);
     this.endTime = new Date(deliveryDay.getTime() + endTimeInMiliseconds);
@@ -76,6 +76,21 @@ public class DeliverySlot {
       throw new BadRequestException("Please enter a valid time!");
     }
     if (startTime.getTime() < System.currentTimeMillis()) {
+      throw new BadRequestException("Please enter a valid date!");
+    }
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.userId = userId;
+  }
+
+  /**
+   * Creates a delivery slot given a date, start and end times in miliseconds and the user id.
+   */
+  public DeliverySlot(Date startTime, Date endTime, String userId, boolean canBeInThePast) throws BadRequestException {
+    if (startTime.compareTo(endTime) > 0) {
+      throw new BadRequestException("Please enter a valid time!");
+    }
+    if (!canBeInThePast && startTime.getTime() < System.currentTimeMillis()) {
       throw new BadRequestException("Please enter a valid date!");
     }
     this.startTime = startTime;
@@ -127,5 +142,11 @@ public class DeliverySlot {
 
   public void setSlotId(String slotId) {
     this.slotId = slotId;
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    DeliverySlot deliverySlot = (DeliverySlot)object;
+    return slotId.equals(deliverySlot.getSlotId());
   }
 }

--- a/src/main/java/com/google/sps/data/DeliverySlot.java
+++ b/src/main/java/com/google/sps/data/DeliverySlot.java
@@ -61,7 +61,7 @@ public class DeliverySlot {
       throw new BadRequestException("Please enter a valid time!");
     }
     if (startTimeInMiliseconds < System.currentTimeMillis() - deliveryDay.getTime()) {
-      throw new ExpiredRequestException("Please enter a valid date!");
+      throw new BadRequestException("Please enter a valid date!");
     }
     this.startTime = new Date(deliveryDay.getTime() + startTimeInMiliseconds);
     this.endTime = new Date(deliveryDay.getTime() + endTimeInMiliseconds);

--- a/src/main/java/com/google/sps/data/DeliverySlot.java
+++ b/src/main/java/com/google/sps/data/DeliverySlot.java
@@ -84,7 +84,9 @@ public class DeliverySlot {
   }
 
   /**
-   * Creates a delivery slot given a date, start and end times in miliseconds and the user id.
+   * Creates a delivery slot given a date, start and end times in miliseconds and the user id. If 
+   * canBeInThePast is set to true, the starting time can be past the current time. The boolean is
+   * necessary for creating and displaying the history of delivery slots.
    */
   public DeliverySlot(Date startTime, Date endTime, String userId, boolean canBeInThePast) throws BadRequestException {
     if (startTime.compareTo(endTime) > 0) {

--- a/src/main/java/com/google/sps/data/DeliverySlotManager.java
+++ b/src/main/java/com/google/sps/data/DeliverySlotManager.java
@@ -21,6 +21,7 @@ import com.google.appengine.api.datastore.EntityNotFoundException;
 import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.maps.model.LatLng;
@@ -90,7 +91,8 @@ public class DeliverySlotManager {
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Query query = new Query("deliverySlotRequest").setFilter(new Query.FilterPredicate("uid", Query.FilterOperator.EQUAL, userId));
-    List<Entity> results = datastore.prepare(query).asList(FetchOptions.Builder.withDefaults());
+    List<Entity> results = datastore.prepare(query.addSort(DeliverySlot.Property.START_TIME.label, SortDirection.ASCENDING))
+      .asList(FetchOptions.Builder.withDefaults());
     
     for (Entity deliverySlotEntity : results) {
       DeliverySlot deliverySlot = new DeliverySlot((Date)deliverySlotEntity.getProperty(DeliverySlot.Property.START_TIME.label),

--- a/src/main/webapp/common.js
+++ b/src/main/webapp/common.js
@@ -221,8 +221,11 @@ async function displayDeliverySlots() {
       return response.json();
     }
   }).then(slots => {
-    // Display each delivery slot as a list element.
+    // Add the past delivery slots in 'past-delivery-slots-container'.
+    const pastDeliverySlotsContainer = document.getElementById('past-delivery-slots-container');
+    // Add the current and future delivery slots in 'delivery-slots-container'.
     const deliverySlotsContainer = document.getElementById('delivery-slots-container');
+    // Display each delivery slot as a list element.
     for (const slot in slots) {
       deliverySlotElem = createUlElement(`Delivery slot with ID: ${slots[slot].slotId}`);
       slotTime = createListElement(`Starts at ${slots[slot].startTime} and ends at ${slots[slot].endTime}`);
@@ -231,7 +234,12 @@ async function displayDeliverySlots() {
       // TODO[ak47na]: improve the way delivery slots are shown (e.g. add line breaks between them).
       deliverySlotElem.appendChild(slotTime);
       deliverySlotElem.appendChild(slotAddress);
-      deliverySlotsContainer.appendChild(deliverySlotElem);
+      if (new Date(slots[slot].startTime) < new Date()) {
+        // The slot is in the past.
+        pastDeliverySlotsContainer.appendChild(deliverySlotElem);
+      } else {
+        deliverySlotsContainer.appendChild(deliverySlotElem);
+      }
     }
   }).catch(error => {
     alert(error);

--- a/src/main/webapp/deliverySlots.html
+++ b/src/main/webapp/deliverySlots.html
@@ -19,7 +19,9 @@
     <div class="menu-container"></div>
 
     <div class="content-container">
-      <h1>Your delivery slots: </h1>
+      <h1>Your past delivery slots: </h1>
+      <ul id="past-delivery-slots-container"></ul>
+      <h1>Your current and future delivery slots: </h1>
       <ul id="delivery-slots-container"></ul>
     </div>
 

--- a/src/test/java/com/google/sps/data/DeliverySlotManagerTest.java
+++ b/src/test/java/com/google/sps/data/DeliverySlotManagerTest.java
@@ -156,6 +156,7 @@ public class DeliverySlotManagerTest {
     deliverySlot3.setStartPoint(0, 0);
     addDeliverySlotRequestEntity(deliverySlot3);
     DeliverySlotManager slotManager = new DeliverySlotManager();
-    assertEquals(Arrays.asList(deliverySlot1, deliverySlot3), slotManager.getUsersDeliverySlotRequests("user1"));
+    // Delivery slots are retrieved in ascending order with respect to the start time.
+    assertEquals(Arrays.asList(deliverySlot3, deliverySlot1), slotManager.getUsersDeliverySlotRequests("user1"));
   }
 }

--- a/src/test/java/com/google/sps/data/DeliverySlotManagerTest.java
+++ b/src/test/java/com/google/sps/data/DeliverySlotManagerTest.java
@@ -83,7 +83,8 @@ public class DeliverySlotManagerTest {
   @Test
   public void testCreateSlotSuccessfully() throws ApiException, IOException, InterruptedException, BadRequestException, DataNotFoundException {
     DeliverySlotManager slotManager = new DeliverySlotManager();
-    DeliverySlot deliverySlot = new DeliverySlot(new Date(2020, 9, 26), 0, 3600000, "user0");
+    Date startDate = new Date(System.currentTimeMillis() + ONE_HOUR);
+    DeliverySlot deliverySlot = new DeliverySlot(startDate, 0, 3600000, "user0");
     deliverySlot.setStartPoint(0.0, 0.0);
     slotManager.createDeliverySlot(deliverySlot);
     // Query datastore and verify that the request is added.
@@ -98,14 +99,14 @@ public class DeliverySlotManagerTest {
     assertEquals("user0", deliverySlots.get(0).getProperty(DeliverySlot.Property.USER_ID.label));
     assertEquals(0.0, deliverySlots.get(0).getProperty(DeliverySlot.Property.START_LAT.label));
     assertEquals(0.0, deliverySlots.get(0).getProperty(DeliverySlot.Property.START_LNG.label));
-    assertEquals(new Date(2020, 9, 26), deliverySlots.get(0).getProperty(DeliverySlot.Property.START_TIME.label));
-    assertEquals(new Date(2020, 9, 26, 1, 0), deliverySlots.get(0).getProperty(DeliverySlot.Property.END_TIME.label));
+    assertEquals(startDate, deliverySlots.get(0).getProperty(DeliverySlot.Property.START_TIME.label));
+    assertEquals(new Date(startDate.getTime() + ONE_HOUR), deliverySlots.get(0).getProperty(DeliverySlot.Property.END_TIME.label));
   }
 
   @Test
   public void testGetSlotSuccessfully() throws ApiException, IOException, InterruptedException, BadRequestException, DataNotFoundException, EntityNotFoundException {
     DeliverySlotManager slotManager = new DeliverySlotManager();
-    DeliverySlot deliverySlot = new DeliverySlot(new Date(2020, 9, 26), 0, 3600000, "user0");
+    DeliverySlot deliverySlot = new DeliverySlot(new Date(System.currentTimeMillis() + ONE_HOUR), 0, 3600000, "user0");
     deliverySlot.setStartPoint(0.0, 0.0);
     slotManager.createDeliverySlot(deliverySlot);
     // The delivery slot request in datastore should be the one added in the previous line.
@@ -121,7 +122,7 @@ public class DeliverySlotManagerTest {
   @Test(expected = BadRequestException.class)
   public void testCreateSlotInvalidDate() throws IOException, BadRequestException {
     DeliverySlotManager slotManager = new DeliverySlotManager();
-    DeliverySlot deliverySlot = new DeliverySlot(new Date(2020, 9, 26), 3600000, 0, "user0");
+    DeliverySlot deliverySlot = new DeliverySlot(new Date(System.currentTimeMillis() + ONE_HOUR), 3600000, 0, "user0");
     deliverySlot.setStartPoint(0.0, 0.0);
     slotManager.createDeliverySlot(deliverySlot);
   }

--- a/src/test/java/com/google/sps/servlets/NewRequestServletTest.java
+++ b/src/test/java/com/google/sps/servlets/NewRequestServletTest.java
@@ -135,7 +135,7 @@ public final class NewRequestServletTest {
    */
   @Test
   public void testNewRequestsAutomaticallyCreatesCourierProfile() throws IOException, ServletException, FirebaseAuthException {
-    when(request.getParameter("delivery-date")).thenReturn("2020-09-26");
+    when(request.getParameter("delivery-date")).thenReturn("2020-10-26");
     when(request.getParameter("start-time")).thenReturn("05:15");
     when(request.getParameter("end-time")).thenReturn("15:10");
     when(request.getParameter("timezone-offset-minutes")).thenReturn("180");


### PR DESCRIPTION
In the previous version, only the delivery slots that started before the current time were valid. However, when past slots were retrieved from Datastore, creating a `DeliverySlot` object was causing `BadRequestException`. 
This PR allows creating and displaying past delivery slots and deletes the slots that started more than 30 days from the current time.
A future PR will schedule a Cron job to delete expired delivery slots everyday at midnight.